### PR TITLE
Remove warning re: production use from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ForgeRock Identity Cloud - Demonstration Configuration Management Tools
 
-<b>Note: This is an alpha release candidate: it should not be used in production in its current state.</b>
+
 
 ## Disclaimer
 


### PR DESCRIPTION
Remove the below statement from the README,

Note: This is an alpha release candidate: it should not be used in production in its current state.