### PR TITLE
199: Handle null themes for a realm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-manager",
-  "version": "1.4.6",
+  "version": "1.4.7-beta.1",
   "description": "Sample tools for managing PingOne Advanced Identity Cloud configuration",
   "devDependencies": {
     "prettier": "2.8.2"

--- a/packages/fr-config-common/package.json
+++ b/packages/fr-config-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-common",
-  "version": "1.4.6",
+  "version": "1.4.7-beta.1",
   "description": "Config tools for Ping Advanced Identity Cloud",
   "main": "src/index.js",
   "scripts": {

--- a/packages/fr-config-promote/package.json
+++ b/packages/fr-config-promote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-promote",
-  "version": "1.4.6",
+  "version": "1.4.7-beta.1",
   "description": "This tool is used to promote configuration from the one ForgeRock Identity Cloud tenant to the other ForgeRock Identity Cloud tenant.",
   "scripts": {
     "lint": "standard",

--- a/packages/fr-config-pull/package.json
+++ b/packages/fr-config-pull/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-pull",
-  "version": "1.4.6",
+  "version": "1.4.7-beta.1",
   "description": "Config tools for FIDC",
   "main": "src/index.js",
   "bin": {

--- a/packages/fr-config-pull/src/scripts/themes.js
+++ b/packages/fr-config-pull/src/scripts/themes.js
@@ -97,7 +97,7 @@ async function exportThemes(exportDir, realms, tenantUrl, name, token) {
         token
       );
 
-      if (!response.data.realm) {
+      if (!response.data.realm || !response.data.realm[realm]) {
         continue;
       }
 

--- a/packages/fr-config-push/package.json
+++ b/packages/fr-config-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-push",
-  "version": "1.4.6",
+  "version": "1.4.7-beta.1",
   "description": "This tool is used to push configuration from the local host to your ForgeRock Identity Cloud tenant.",
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
If themes for a realm are nulled, this can cause following exception when fetching themes

Getting themes
TypeError: Cannot read properties of null (reading 'forEach')
    at processThemes (/Users/christian.brindley/cicd/fr-config-manager/packages/fr-config-pull/src/scripts/themes.js:18:12)
    at Object.exportThemes (/Users/christian.brindley/cicd/fr-config-manager/packages/fr-config-pull/src/scripts/themes.js:107:7)


