### PR TITLE
258 ordering of saml cot push wrong

### DIFF
--- a/packages/fr-config-common/package.json
+++ b/packages/fr-config-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-common",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Config tools for Ping Advanced Identity Cloud",
   "main": "src/index.js",
   "scripts": {

--- a/packages/fr-config-promote/package.json
+++ b/packages/fr-config-promote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-promote",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "This tool is used to promote configuration from the one ForgeRock Identity Cloud tenant to the other ForgeRock Identity Cloud tenant.",
   "scripts": {
     "lint": "standard",

--- a/packages/fr-config-pull/package.json
+++ b/packages/fr-config-pull/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-pull",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Config tools for FIDC",
   "main": "src/index.js",
   "bin": {

--- a/packages/fr-config-push/package.json
+++ b/packages/fr-config-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgerock/fr-config-push",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "This tool is used to push configuration from the local host to your ForgeRock Identity Cloud tenant.",
   "scripts": {
     "lint": "standard",

--- a/packages/fr-config-push/src/scripts/update-saml.js
+++ b/packages/fr-config-push/src/scripts/update-saml.js
@@ -197,7 +197,6 @@ async function handleCOTs(
 
   const cotName = samlObject._id;
   const cotEndpoint = getCotEndpoint(tenantUrl, realm, cotName);
-  console.log("Updating COT", `"${JSON.stringify(samlObject)}"`);
   await restPutFn(cotEndpoint, samlObject, token, PROTOCOL_RESOURCE_HEADER);
 }
 
@@ -285,7 +284,7 @@ const updateSaml = async (argv, token) => {
               handleHostedSAMLEntity(samlObject, amSamlBaseUrl, token);
               break;
             case "cot":
-              //handleCOTs(samlObject, TENANT_BASE_URL, realm, token, restPut);
+              //do nothing, COTs are handled separately
               break;
             default:
               console.error(`Unknown SAML type: ${samlType}`);
@@ -298,7 +297,6 @@ const updateSaml = async (argv, token) => {
         const samlFiles = fs
           .readdirSync(dir)
           .filter((name) => path.extname(name) === ".json");
-        console.log("COT files", samlFiles);
         for (const samlFile of samlFiles) {
           const samlFilePath = path.join(dir, samlFile);
           const samlFileContents = fs.readFileSync(samlFilePath, "utf8");

--- a/packages/fr-config-push/src/scripts/update-saml.js
+++ b/packages/fr-config-push/src/scripts/update-saml.js
@@ -278,10 +278,10 @@ const updateSaml = async (argv, token) => {
           }
           switch (samlType.toLowerCase()) {
             case "remote":
-              handleRemoteSAMLEntity(samlObject, amSamlBaseUrl, token);
+              await handleRemoteSAMLEntity(samlObject, amSamlBaseUrl, token);
               break;
             case "hosted":
-              handleHostedSAMLEntity(samlObject, amSamlBaseUrl, token);
+              await handleHostedSAMLEntity(samlObject, amSamlBaseUrl, token);
               break;
             case "cot":
               //do nothing, COTs are handled separately
@@ -304,7 +304,7 @@ const updateSaml = async (argv, token) => {
             replaceEnvSpecificValues(samlFileContents);
           const samlObject = JSON.parse(resolvedSamlFileContents);
 
-          handleCOTs(samlObject, TENANT_BASE_URL, realm, token);
+          await handleCOTs(samlObject, TENANT_BASE_URL, realm, token);
         }
       }
     } catch (error) {


### PR DESCRIPTION
COT has to be pushed after the SAML entities so that the COT can reference existing entities.