### PR TITLE
fix(secrets): resolve early exit when filtering by name in fr-config-pull

### DIFF
--- a/packages/fr-config-pull/src/scripts/secrets.js
+++ b/packages/fr-config-pull/src/scripts/secrets.js
@@ -27,7 +27,7 @@ async function exportConfig(exportDir, tenantUrl, name, activeOnly, report, toke
 
     for (const secret of secrets) {
       if (name && name !== secret._id) {
-        return;
+        continue;
       }
 
       if (report) {


### PR DESCRIPTION
Resolves #388

### Description
When running `fr-config-pull secrets` with the `-n` or `--name` flag, the command previously failed to create any files if the requested secret was not the very first one returned by the API. 

This occurred because the filtering logic inside the `for...of` loop was using a `return;` statement. In a `for...of` loop, `return;` causes the entire `exportConfig` function to exit prematurely rather than just skipping the current iteration (unlike in a `.forEach()` loop where it behaves like a continue).

### Changes Made
- Modified `packages/fr-config-pull/src/scripts/secrets.js` to replace `return;` with `continue;`.
- This ensures the loop correctly skips non-matching secrets and properly evaluates all returned secrets until the match is found.

### Testing
- Tested locally by running `fr-config-pull secrets --name <secret-name>` and verified that the specific secret configuration file is successfully created in the target directory.