### PR TITLE
remove log of full api response

### DIFF
--- a/packages/fr-config-common/src/restClient.js
+++ b/packages/fr-config-common/src/restClient.js
@@ -247,7 +247,6 @@ async function httpRequest(
         return null;
       } else {
         console.error(`Exception processing request to ${requestUrl}`);
-        console.error(error.response?.data);
         console.error(JSON.stringify(error, null, 2));
         responseError = true;
       }


### PR DESCRIPTION
This removes the `console.error` message that was logging the entire response body for failed API requests, including sensitive information like the access token.

Closes #386.